### PR TITLE
Request controller

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,7 +11,8 @@ const logger = require("morgan");
 
 const authRouter = require("./routes/auth");
 const userRouter = require("./routes/user");
-const profileRouter = require('./routes/profile');
+const profileRouter = require("./routes/profile");
+const requestRouter = require("./routes/request");
 
 const { json, urlencoded } = express;
 
@@ -45,6 +46,7 @@ app.use((req, res, next) => {
 app.use("/auth", authRouter);
 app.use("/users", userRouter);
 app.use("/profile", profileRouter);
+app.use("/requests", requestRouter);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/client/build")));

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -1,0 +1,70 @@
+const Request = require("../models/Request");
+const asyncHandler = require("express-async-handler");
+
+// @route GET /requests
+// @desc get requests for logged in user
+// @access Private
+exports.getRequests = asyncHandler(async (req, res) => {
+  const requests = await Request.find({
+    sitterId: req.user.id,
+  });
+
+  res.status(200).json({
+    success: { requests },
+  });
+});
+
+// @route POST /requests
+// @desc Create a new request
+// @access Private
+exports.createRequest = asyncHandler(async (req, res) => {
+  const { sitterId, start, end } = req.body;
+  const request = await Request.create({
+    userId: req.user.id,
+    sitterId,
+    start: start,
+    end: end,
+    status: "pending",
+  });
+
+  if (!request) {
+    res.status(400);
+    throw new Error("Bad request");
+  }
+
+  res.status(201).json({
+    success: { request },
+  });
+});
+
+// @route PUT /requests/
+// @desc Update request status
+// @access Private
+exports.updateRequestStatus = asyncHandler(async (req, res) => {
+  const { status } = req.body;
+  const validStatuses = ["declined", "accepted"];
+  if (!validStatuses.includes(status)) {
+    res.status(400);
+    throw new Error("Bad request");
+  }
+
+  const { requestId } = req.params;
+  const request = await Request.findById(requestId);
+
+  if (!request) {
+    throw new Error("Bad request");
+  }
+
+  const { sitterId } = request;
+  if (req.user.id !== sitterId.toString()) {
+    res.status(401);
+    throw new Error("Not authorized");
+  }
+
+  request.status = status;
+  const updatedRequest = await request.save();
+
+  res.status(200).json({
+    success: { request: updatedRequest },
+  });
+});

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -19,6 +19,14 @@ exports.getRequests = asyncHandler(async (req, res) => {
 // @access Private
 exports.createRequest = asyncHandler(async (req, res) => {
   const { sitterId, start, end } = req.body;
+
+  const propertyIsMissing = !sitterId || !start || !end;
+
+  if (propertyIsMissing || !mongoose.Types.ObjectId.isValid(sitterId)) {
+    res.status(400);
+    throw new Error("Bad request");
+  }
+
   const request = await Request.create({
     userId: req.user.id,
     sitterId,
@@ -28,8 +36,8 @@ exports.createRequest = asyncHandler(async (req, res) => {
   });
 
   if (!request) {
-    res.status(400);
-    throw new Error("Bad request");
+    res.status(500);
+    throw new Error("Internal server error");
   }
 
   res.status(201).json({
@@ -50,6 +58,11 @@ exports.updateRequestStatus = asyncHandler(async (req, res) => {
 
   const { requestId } = req.params;
   const request = await Request.findById(requestId);
+
+  if (!mongoose.Types.ObjectId.isValid(requestId)) {
+    res.status(400);
+    throw new Error("Bad request");
+  }
 
   if (!request) {
     throw new Error("Bad request");

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -37,7 +37,7 @@ exports.createRequest = asyncHandler(async (req, res) => {
   });
 });
 
-// @route PUT /requests/
+// @route PATCH /requests/
 // @desc Update request status
 // @access Private
 exports.updateRequestStatus = asyncHandler(async (req, res) => {

--- a/server/routes/request.js
+++ b/server/routes/request.js
@@ -9,6 +9,6 @@ const {
 
 router.route("/").get(protect, getRequests);
 router.route("/").post(protect, createRequest);
-router.route("/:requestId").put(protect, updateRequestStatus);
+router.route("/:requestId").patch(protect, updateRequestStatus);
 
 module.exports = router;

--- a/server/routes/request.js
+++ b/server/routes/request.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const protect = require("../middleware/auth");
+const {
+  getRequests,
+  createRequest,
+  updateRequestStatus,
+} = require("../controllers/request");
+
+router.route("/").get(protect, getRequests);
+router.route("/").post(protect, createRequest);
+router.route("/:requestId").put(protect, updateRequestStatus);
+
+module.exports = router;


### PR DESCRIPTION
Closes #8

### What this PR does:
- Creates the API endpoint for `/requests`
  - owner clients can POST new requests
  - sitter clients can GET their requests
  - sitter clients can send PUT requests to set request statuses to "declined" or "accepted" 

### Any information needed to test this feature:
- At the time this PR is created, an http client must be used to test the endpoints

