### PR TITLE
Integrate Manage Bookings UI to use database 

### DIFF
--- a/client/src/components/BookingList/BookingCard.tsx
+++ b/client/src/components/BookingList/BookingCard.tsx
@@ -22,11 +22,11 @@ const BookingCard = ({ booking }: PropTypes) => {
         <Box sx={{ height: '10px' }}></Box>
         <Grid container alignItems="center">
           <Grid item xs={2}>
-            <Avatar src={`https://robohash.org/${booking.user.email}`}>{booking.user.name[0]}</Avatar>
+            <Avatar src={`https://robohash.org/${booking.sitter.email}`}>{booking.sitter.name[0]}</Avatar>
           </Grid>
           <Grid item xs={7}>
             <Typography sx={{ fontSize: '0.8rem', fontWeight: 'bold', marginLeft: '5px' }}>
-              {booking.user.name}
+              {booking.sitter.name}
             </Typography>
           </Grid>
           <Grid item xs={3}>

--- a/client/src/components/NextBookings/NextBooking.tsx
+++ b/client/src/components/NextBookings/NextBooking.tsx
@@ -21,9 +21,9 @@ const NextBooking = ({ booking }: PropTypes) => {
           {format(booking.start, 'd LLLL y, haaa')} - {format(booking.end, 'haaa')}
         </Typography>
         <Grid container direction="row" alignItems="center">
-          <Avatar src={`https://robohash.org/${booking.user.email}`}>{booking.user.name[0]}</Avatar>
+          <Avatar src={`https://robohash.org/${booking.sitter.email}`}>{booking.sitter.name[0]}</Avatar>
           <Typography sx={{ fontSize: '0.9rem', fontWeight: 'bold', marginLeft: '5px' }}>
-            {booking.user.name}
+            {booking.sitter.name}
           </Typography>
         </Grid>
       </CardContent>

--- a/client/src/helpers/APICalls/requests.ts
+++ b/client/src/helpers/APICalls/requests.ts
@@ -1,0 +1,14 @@
+import { Booking } from '../../interface/Booking';
+
+interface BookingResponse {
+  success?: {
+    requests: Booking[];
+  };
+  error?: string;
+}
+
+export const getBookings = async (sitter = false): Promise<BookingResponse> => {
+  const url = '/requests' + (sitter ? '?isSitter=true' : '');
+  const response = await fetch(url);
+  return response.json();
+};

--- a/client/src/interface/Booking.ts
+++ b/client/src/interface/Booking.ts
@@ -6,5 +6,6 @@ export interface Booking {
   start: Date;
   end: Date;
   status: Status;
-  user: User;
+  sitter: User;
+  owner: User;
 }

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -28,7 +28,7 @@ const Bookings = () => {
         });
         setBookings(success.requests);
       } else {
-        throw new Error('Error fetching bookings from server');
+        updateSnackBarMessage('Error fetching bookings from server');
       }
     } catch (e) {
       const { message } = e as Error;

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -35,7 +35,7 @@ const Bookings = () => {
     history.push('/login');
     return <CircularProgress />;
   }
-  const acceptedBookings = bookings.filter((b) => b.status === 'declined');
+  const acceptedBookings = bookings.filter((b) => b.status !== 'declined');
   const highlightedDates = acceptedBookings.map((b) => b.start.toString().slice(0, 10));
 
   const currentBookings: Booking[] = [];
@@ -48,7 +48,6 @@ const Bookings = () => {
   }
 
   const nextBooking = currentBookings.shift();
-  console.log(nextBooking);
 
   const scrollableCardStyles = {
     padding: '0px 10px 10px 10px',

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -1,17 +1,16 @@
 const Request = require("../models/Request");
+const Profile = require("../models/Profile");
 const asyncHandler = require("express-async-handler");
 
 // @route GET /requests/sitter
 // @desc get requests for logged in user
 // @access Private
 exports.getRequests = asyncHandler(async (req, res) => {
-  const { isSitter } = req.query ?? "false";
-  if (!["true", "false"].includes(isSitter ?? "false")) {
-    res.status(400);
-    throw new Error("Bad Request");
-  }
-
-  const selectedUserType = isSitter === "true" ? "sitter" : "owner";
+  const { isSitter } = await Profile.findOne(
+    { userId: req.user.id },
+    "isSitter -_id"
+  );
+  const selectedUserType = isSitter ? "sitter" : "owner";
   const requests = await Request.find({
     [selectedUserType]: req.user.id,
   })

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -1,13 +1,24 @@
 const Request = require("../models/Request");
 const asyncHandler = require("express-async-handler");
 
-// @route GET /requests
+// @route GET /requests/sitter
 // @desc get requests for logged in user
 // @access Private
 exports.getRequests = asyncHandler(async (req, res) => {
+  const { isSitter } = req.query ?? "false";
+  if (!["true", "false"].includes(isSitter ?? "false")) {
+    res.status(400);
+    throw new Error("Bad Request");
+  }
+
+  const selectedUserType = isSitter === "true" ? "sitter" : "owner";
   const requests = await Request.find({
-    sitterId: req.user.id,
-  });
+    [selectedUserType]: req.user.id,
+  })
+    .populate("sitter")
+    .populate("owner")
+    .sort("start")
+    .exec();
 
   res.status(200).json({
     success: { requests },
@@ -18,10 +29,11 @@ exports.getRequests = asyncHandler(async (req, res) => {
 // @desc Create a new request
 // @access Private
 exports.createRequest = asyncHandler(async (req, res) => {
-  const { sitterId, start, end } = req.body;
+  const { sitter, start, end } = req.body;
+
   const request = await Request.create({
-    userId: req.user.id,
-    sitterId,
+    owner: req.user.id,
+    sitter,
     start: start,
     end: end,
     status: "pending",
@@ -55,8 +67,8 @@ exports.updateRequestStatus = asyncHandler(async (req, res) => {
     throw new Error("Bad request");
   }
 
-  const { sitterId } = request;
-  if (req.user.id !== sitterId.toString()) {
+  const { sitter } = request;
+  if (req.user.id !== sitter.toString()) {
     res.status(401);
     throw new Error("Not authorized");
   }

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -4,7 +4,12 @@ const profileSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,
-    ref: 'User'
+    ref: "User",
+  },
+  isSitter: {
+    type: Boolean,
+    required: true,
+    default: false,
   },
   name: {
     type: String,
@@ -16,7 +21,7 @@ const profileSchema = new mongoose.Schema({
   },
   gender: {
     type: String,
-    enum: ['male', 'female', 'other'],
+    enum: ["male", "female", "other"],
   },
   address: {
     type: String,
@@ -28,7 +33,7 @@ const profileSchema = new mongoose.Schema({
   },
   birthday: {
     type: Date,
-    default: null
+    default: null,
   },
   photo: {
     type: String,

--- a/server/models/Request.js
+++ b/server/models/Request.js
@@ -4,14 +4,14 @@ const { ObjectId } = Schema.Types;
 const required = true;
 
 const requestSchema = new Schema({
-  userId: {
+  owner: {
     type: ObjectId,
-    ref: "User",
+    ref: "user",
     required,
   },
-  sitterId: {
+  sitter: {
     type: ObjectId,
-    ref: "User",
+    ref: "user",
     required,
   },
   start: {
@@ -41,7 +41,7 @@ const requestSchema = new Schema({
   },
   status: {
     type: String,
-    enum: ["pending", "accepted", "paid"],
+    enum: ["pending", "accepted", "declined", "paid"],
     default: "pending",
   },
 });


### PR DESCRIPTION
Closes #31 

### What this PR does:
-Manage bookings interface now uses the database rather than using hard-coded values

### Screenshots / Videos (front-end only):
![Screenshot 2022-01-19 031753](https://user-images.githubusercontent.com/66583830/150120596-a4db56a1-a725-4052-94ba-31fddce2b775.png)
![Screenshot 2022-01-19 031828](https://user-images.githubusercontent.com/66583830/150120656-c3fb3802-51d7-4e86-9b26-6f8be6ac3517.png)

### Any information needed to test this feature:
- I created all test users using the ui
- I created the requests using an http client
- go to url: `/bookings`

### Info
- Request model properties are no longer called `userId` and `sitterId`. They are now called `owner` and `sitter`.
  - This is to take advantage of mongoose's `populate` method
- `GET /requests` now takes an `isSitter` query param to specify whether we want to get requests where the logged in user is a sitter, or whether they are an owner
  - It is treated as false if omitted
