### PR TITLE
Bug Fix: Auth Provider Redirect

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,14 +15,14 @@ import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
-const unAuthRoutes = ['/', '/login', '/signup'];
+const unAuthUserRoutes = ['/', '/login', '/signup'];
 
 function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>
         <SnackBarProvider>
-          <AuthProvider unAuthRoutes={unAuthRoutes}>
+          <AuthProvider unAuthUserRoutes={unAuthUserRoutes}>
             <SocketProvider>
               <CssBaseline />
               <Navbar />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,7 @@ import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
-const unAuthUserRoutes = ['/', '/login', '/signup'];
+const unAuthUserRoutes = ['/', '/login', '/signup', '/listings'];
 
 function App(): JSX.Element {
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,12 +15,14 @@ import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
+const unAuthRoutes = ['/', '/login', '/signup'];
+
 function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>
         <SnackBarProvider>
-          <AuthProvider>
+          <AuthProvider unAuthRoutes={unAuthRoutes}>
             <SocketProvider>
               <CssBaseline />
               <Navbar />

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -19,7 +19,11 @@ export const AuthContext = createContext<IAuthContext>({
   logout: () => null,
 });
 
-export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
+interface Props {
+  unAuthRoutes: string[];
+}
+
+export const AuthProvider: FunctionComponent<Props> = ({ children, unAuthRoutes }): JSX.Element => {
   // default undefined before loading, once loaded provide user or null if logged out
   const [loggedInUser, setLoggedInUser] = useState<User | null | undefined>();
   const [profile, setProfile] = useState();
@@ -57,14 +61,14 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
         } else {
           // don't need to provide error feedback as this just means user doesn't have saved cookies or the cookies have not been authenticated on the backend
           setLoggedInUser(null);
-          if (!(history.location.pathname === '/signup')) {
+          if (!unAuthRoutes.includes(history.location.pathname)) {
             history.push('/login');
           }
         }
       });
     };
     checkLoginWithCookies();
-  }, [updateLoginContext, history]);
+  }, [updateLoginContext, unAuthRoutes, history]);
 
   return (
     <AuthContext.Provider value={{ loggedInUser, profile, updateLoginContext, logout }}>

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -20,10 +20,10 @@ export const AuthContext = createContext<IAuthContext>({
 });
 
 interface Props {
-  unAuthRoutes: string[];
+  unAuthUserRoutes: string[];
 }
 
-export const AuthProvider: FunctionComponent<Props> = ({ children, unAuthRoutes }): JSX.Element => {
+export const AuthProvider: FunctionComponent<Props> = ({ children, unAuthUserRoutes }): JSX.Element => {
   // default undefined before loading, once loaded provide user or null if logged out
   const [loggedInUser, setLoggedInUser] = useState<User | null | undefined>();
   const [profile, setProfile] = useState();
@@ -61,14 +61,14 @@ export const AuthProvider: FunctionComponent<Props> = ({ children, unAuthRoutes 
         } else {
           // don't need to provide error feedback as this just means user doesn't have saved cookies or the cookies have not been authenticated on the backend
           setLoggedInUser(null);
-          if (!unAuthRoutes.includes(history.location.pathname)) {
+          if (!unAuthUserRoutes.includes(history.location.pathname)) {
             history.push('/login');
           }
         }
       });
     };
     checkLoginWithCookies();
-  }, [updateLoginContext, unAuthRoutes, history]);
+  }, [updateLoginContext, unAuthUserRoutes, history]);
 
   return (
     <AuthContext.Provider value={{ loggedInUser, profile, updateLoginContext, logout }}>


### PR DESCRIPTION
### Closes #62 
### What this PR does (required):
#### Updated Contexts
##### 1. AuthProvider
###### props
- unAuthUserRoutes -> an array of strings representing all of the routes an unauthorized user is allowed to visit.

### Screenshots / Videos (front-end only):
#### 1.This is the current functionality - redirects you to login page, even when attempting to view landing page.
![Current Functionality](https://user-images.githubusercontent.com/64337339/150585147-564c736a-c63f-4f68-9be4-f3659945ee2d.gif)

#### 2.This is the newly updated functionality - allows unauthorized users to visit any page that does not require access.
![Updated Functionality](https://user-images.githubusercontent.com/64337339/150585312-ccd3ac5c-7396-4df0-b1cc-119911a395bb.gif)

### Any information needed to test this feature (required):
- Sign out of user account
- Attempt to visit http://localhost:3000/
- Attempt to visit pages only a user can access, IE: http://localhost:3000/dashboard. (Redirects you to login page).