### PR TITLE
Feature: Filtered Navbar Items

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 import { FinalCheck, MenuItemData } from './interface/Navbar';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useMemo } from 'react';
 import clsx from 'clsx';
 import { useAuth } from '../../context/useAuthContext';
 import {
@@ -116,10 +116,8 @@ const Navbar: React.FC = () => {
     logout();
   };
 
-  const checkCanView = useCallback<FinalCheck>(
-    (canView, authenticated) => checkProfile(profile, loggedInUser)(canView, authenticated),
-    [loggedInUser, profile],
-  );
+  const checkCanView = useMemo<FinalCheck>(() => checkProfile(profile, loggedInUser), [loggedInUser, profile]);
+
   const renderMenuItems = () =>
     menuItems.map((menu, index) => {
       if (checkCanView(menu.canView, menu.authenticated)) {

--- a/client/src/components/Navbar/interface/Navbar.ts
+++ b/client/src/components/Navbar/interface/Navbar.ts
@@ -1,0 +1,17 @@
+import { AccountTypeKey, AccountTypeVal } from './../../../types/AccountType';
+import { User } from '../../../interface/User';
+
+export interface MenuItemData {
+  item: string | JSX.Element;
+  resource?: string;
+  canView: AccountTypeVal[] | null;
+  authenticated: boolean;
+}
+
+interface PartialProfile {
+  isSitter: boolean;
+}
+
+export type FinalCheck = (canView: AccountTypeVal[] | null, authenticated: boolean) => boolean;
+export type CheckCanView = (type: AccountTypeKey) => FinalCheck;
+export type CheckProfile = (profile?: PartialProfile, user?: User | null) => FinalCheck;

--- a/client/src/components/Navbar/utils/checkCanView.ts
+++ b/client/src/components/Navbar/utils/checkCanView.ts
@@ -1,0 +1,7 @@
+import type { CheckCanView } from '../interface/Navbar';
+import { AccountType } from '../../../types/AccountType';
+
+const checkCanView: CheckCanView = (type) => (canView, authenticated) =>
+  canView && canView.includes(AccountType[type]) && authenticated ? true : false;
+
+export default checkCanView;

--- a/client/src/components/Navbar/utils/checkProfile.ts
+++ b/client/src/components/Navbar/utils/checkProfile.ts
@@ -1,0 +1,10 @@
+import { CheckProfile } from '../interface/Navbar';
+import checkCanView from './checkCanView';
+
+const checkProfile: CheckProfile = (profile, user) => {
+  if (profile?.isSitter && user) return checkCanView('PET_SITTER');
+  else if (user) return checkCanView('PET_OWNER');
+  return (canView, authenticated) => !user && !authenticated && !canView;
+};
+
+export default checkProfile;

--- a/client/src/components/Navbar/utils/index.ts
+++ b/client/src/components/Navbar/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as checkProfile } from './checkProfile';

--- a/client/src/types/AccountType.ts
+++ b/client/src/types/AccountType.ts
@@ -2,3 +2,6 @@ export const AccountType = {
   PET_SITTER: 'pet_sitter',
   PET_OWNER: 'pet_owner',
 } as const;
+
+export type AccountTypeKey = keyof typeof AccountType;
+export type AccountTypeVal = typeof AccountType[AccountTypeKey];


### PR DESCRIPTION
### Closes #54 
### What this PR does (required):
- Filters a user's navbar depending on their account type and authentication state.
- If user is not signed in, currently, only three links are made available ("Become a sitter", "Login", and "Sign up").
- If a user is a sitter, only two links will appear. ("My jobs", and "Messages").
- if a user is not a sitter, three links will appear ("Become a sitter", "My sitters" and "Messages").

### Screenshots / Videos (front-end only):
![Account Type Navigation](https://user-images.githubusercontent.com/64337339/150631571-9f737caf-ba0c-42a9-9698-8d1ff4aa2c06.gif)


### Any information needed to test this feature (required):
- To test all three cases:
- Open a private window, should see the unauthenticated user's navbar items
- Login as a user, depending on whether or not the user is a sitter, you will see the other available routes.
- Simply update the isSitter value associated with the user's profile to see the other two possible navbar styles.
