### PR TITLE
Implements bookings context and refactors manage bookings UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,7 @@ function App(): JSX.Element {
                 <CssBaseline />
                 <Navbar />
                 <Switch>
-                  <Route exact path="/bookings" component={Bookings} />
+                  <ProtectedRoute exact path="/bookings" component={Bookings} />
                   <Route exact path="/login" component={Login} />
                   <Route exact path="/signup" component={Signup} />
                   <Route exact path="/dashboard" component={Dashboard} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 import Bookings from './pages/Bookings/Bookings';
 import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
+import { BookingsProvider } from './context/useBookingsContext';
 
 const unAuthUserRoutes = ['/', '/login', '/signup', '/listings'];
 
@@ -26,19 +27,21 @@ function App(): JSX.Element {
         <SnackBarProvider>
           <AuthProvider unAuthUserRoutes={unAuthUserRoutes}>
             <SocketProvider>
-              <CssBaseline />
-              <Navbar />
-              <Switch>
-                <Route exact path="/bookings" component={Bookings} />
-                <Route exact path="/login" component={Login} />
-                <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard" component={Dashboard} />
-                <Route exact path="/listings" component={ProfileListings} />
-                <Route path="/profile/settings" component={Settings} />
-                <Route path="*">
-                  <NotFound />
-                </Route>
-              </Switch>
+              <BookingsProvider>
+                <CssBaseline />
+                <Navbar />
+                <Switch>
+                  <Route exact path="/bookings" component={Bookings} />
+                  <Route exact path="/login" component={Login} />
+                  <Route exact path="/signup" component={Signup} />
+                  <Route exact path="/dashboard" component={Dashboard} />
+                  <Route exact path="/listings" component={ProfileListings} />
+                  <Route path="/profile/settings" component={Settings} />
+                  <Route path="*">
+                    <NotFound />
+                  </Route>
+                </Switch>
+              </BookingsProvider>
             </SocketProvider>
           </AuthProvider>
         </SnackBarProvider>

--- a/client/src/components/BookingList/BookingCard.tsx
+++ b/client/src/components/BookingList/BookingCard.tsx
@@ -15,16 +15,16 @@ const BookingCard = ({ booking }: PropTypes) => {
           <Typography sx={{ fontSize: '0.8rem' }}>
             {format(booking.start, 'd LLLL y, haaa')} - {format(booking.end, 'haaa')}
           </Typography>
-          <HandleRequestButton />
+          <HandleRequestButton bookingId={booking._id} />
         </Grid>
         <Box sx={{ height: '10px' }}></Box>
         <Grid container alignItems="center">
           <Grid item xs={2}>
-            <Avatar src={`https://robohash.org/${booking.sitter.email}`}>{booking.sitter.name[0]}</Avatar>
+            <Avatar src={`https://robohash.org/${booking.otherUser.email}`}>{booking.otherUser.name[0]}</Avatar>
           </Grid>
           <Grid item xs={7}>
             <Typography sx={{ fontSize: '0.8rem', fontWeight: 'bold', marginLeft: '5px' }}>
-              {booking.sitter.name}
+              {booking.otherUser.name}
             </Typography>
           </Grid>
           <Grid item xs={3}>

--- a/client/src/components/BookingList/BookingCard.tsx
+++ b/client/src/components/BookingList/BookingCard.tsx
@@ -1,7 +1,7 @@
 import { Booking } from '../../interface/Booking';
-import { Avatar, Card, CardContent, Grid, IconButton, Typography, Box } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
+import { Avatar, Card, CardContent, Grid, Typography, Box } from '@mui/material';
 import format from 'date-fns/format';
+import HandleRequestButton from '../HandleRequestButton/HandleRequestButton';
 
 interface PropTypes {
   booking: Booking;
@@ -15,9 +15,7 @@ const BookingCard = ({ booking }: PropTypes) => {
           <Typography sx={{ fontSize: '0.8rem' }}>
             {format(booking.start, 'd LLLL y, haaa')} - {format(booking.end, 'haaa')}
           </Typography>
-          <IconButton>
-            <SettingsIcon />
-          </IconButton>
+          <HandleRequestButton />
         </Grid>
         <Box sx={{ height: '10px' }}></Box>
         <Grid container alignItems="center">

--- a/client/src/components/HandleRequestButton/HandleRequestButton.tsx
+++ b/client/src/components/HandleRequestButton/HandleRequestButton.tsx
@@ -16,7 +16,7 @@ const HandleRequestButton = ({ bookingId }: PropTypes) => {
   const { profile } = useAuth();
   const { updateSnackBarMessage } = useSnackBar();
 
-  if (!profile.isSitter) {
+  if (!profile?.isSitter) {
     return <></>;
   }
 

--- a/client/src/components/HandleRequestButton/HandleRequestButton.tsx
+++ b/client/src/components/HandleRequestButton/HandleRequestButton.tsx
@@ -1,16 +1,36 @@
 import { IconButton, Menu, MenuItem } from '@mui/material';
 import { MouseEvent, useState } from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
+import { Status } from '../../interface/Booking';
+import { useBookings } from '../../context/useBookingsContext';
+import { useAuth } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
 
-const HandleRequestButton = () => {
+interface PropTypes {
+  bookingId: string;
+}
+
+const HandleRequestButton = ({ bookingId }: PropTypes) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const { setBookingStatus } = useBookings();
+  const { profile } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+
+  if (!profile.isSitter) {
+    return <></>;
+  }
+
   const open = Boolean(anchorEl);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = (action: string) => {
+  const handleClose = (status?: Status) => {
+    if (status) {
+      setBookingStatus(bookingId, status);
+      updateSnackBarMessage('Request ' + status);
+    }
     setAnchorEl(null);
   };
 
@@ -26,7 +46,7 @@ const HandleRequestButton = () => {
         id="basic-menu"
         anchorEl={anchorEl}
         open={open}
-        onClose={handleClose}
+        onClose={() => handleClose()}
         MenuListProps={{
           'aria-labelledby': 'basic-button',
         }}

--- a/client/src/components/HandleRequestButton/HandleRequestButton.tsx
+++ b/client/src/components/HandleRequestButton/HandleRequestButton.tsx
@@ -1,0 +1,40 @@
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import { MouseEvent, useState } from 'react';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+const HandleRequestButton = () => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (action: string) => {
+    setAnchorEl(null);
+  };
+
+  const handleDecline = () => handleClose('declined');
+  const handleAccept = () => handleClose('accepted');
+
+  return (
+    <>
+      <IconButton onClick={handleClick}>
+        <SettingsIcon />
+      </IconButton>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
+      >
+        <MenuItem onClick={handleAccept}>Accept</MenuItem>
+        <MenuItem onClick={handleDecline}>Decline</MenuItem>
+      </Menu>
+    </>
+  );
+};
+export default HandleRequestButton;

--- a/client/src/components/HandleRequestButton/HandleRequestButton.tsx
+++ b/client/src/components/HandleRequestButton/HandleRequestButton.tsx
@@ -26,10 +26,10 @@ const HandleRequestButton = ({ bookingId }: PropTypes) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = (status?: Status) => {
+  const handleClose = async (status?: Status) => {
     if (status) {
-      setBookingStatus(bookingId, status);
-      updateSnackBarMessage('Request ' + status);
+      const { success } = await setBookingStatus(bookingId, status);
+      if (success) updateSnackBarMessage('Request ' + status);
     }
     setAnchorEl(null);
   };

--- a/client/src/components/NextBookings/NextBooking.tsx
+++ b/client/src/components/NextBookings/NextBooking.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Card, CardContent, Grid, Typography } from '@mui/material';
+import { Avatar, Card, CardContent, Grid, Typography } from '@mui/material';
 import format from 'date-fns/format';
 import { Booking } from '../../interface/Booking';
 import HandleRequestButton from '../HandleRequestButton/HandleRequestButton';
@@ -9,19 +9,19 @@ interface PropTypes {
 
 const NextBooking = ({ booking }: PropTypes) => {
   return (
-    <Card sx={{ padding: '10px 0px 30px 20px' }}>
+    <Card sx={{ padding: '10px 0px 30px 20px', minWidth: '280px' }}>
       <CardContent>
         <Grid container direction="row" justifyContent="space-between" alignItems="flex-end">
           <Typography sx={{ fontVariant: 'small-caps', fontWeight: 'bold' }}>your next booking:</Typography>
-          <HandleRequestButton />
+          <HandleRequestButton bookingId={booking._id} />
         </Grid>
         <Typography sx={{ margin: '10px 0px' }}>
           {format(booking.start, 'd LLLL y, haaa')} - {format(booking.end, 'haaa')}
         </Typography>
         <Grid container direction="row" alignItems="center">
-          <Avatar src={`https://robohash.org/${booking.sitter.email}`}>{booking.sitter.name[0]}</Avatar>
+          <Avatar src={`https://robohash.org/${booking.otherUser.email}`}>{booking.otherUser.name[0]}</Avatar>
           <Typography sx={{ fontSize: '0.9rem', fontWeight: 'bold', marginLeft: '5px' }}>
-            {booking.sitter.name}
+            {booking.otherUser.name}
           </Typography>
         </Grid>
       </CardContent>

--- a/client/src/components/NextBookings/NextBooking.tsx
+++ b/client/src/components/NextBookings/NextBooking.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Card, CardContent, Grid, IconButton, Typography } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
+import { Avatar, Box, Card, CardContent, Grid, Typography } from '@mui/material';
 import format from 'date-fns/format';
 import { Booking } from '../../interface/Booking';
+import HandleRequestButton from '../HandleRequestButton/HandleRequestButton';
 
 interface PropTypes {
   booking: Booking;
@@ -13,9 +13,7 @@ const NextBooking = ({ booking }: PropTypes) => {
       <CardContent>
         <Grid container direction="row" justifyContent="space-between" alignItems="flex-end">
           <Typography sx={{ fontVariant: 'small-caps', fontWeight: 'bold' }}>your next booking:</Typography>
-          <IconButton>
-            <SettingsIcon />
-          </IconButton>
+          <HandleRequestButton />
         </Grid>
         <Typography sx={{ margin: '10px 0px' }}>
           {format(booking.start, 'd LLLL y, haaa')} - {format(booking.end, 'haaa')}

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -31,7 +31,6 @@ export const AuthProvider: FunctionComponent<Props> = ({ children, unAuthUserRou
 
   const updateLoginContext = useCallback(
     (data: AuthApiDataSuccess) => {
-      console.log(data);
       setLoggedInUser(data.user);
       setProfile(data.profile);
       if (data.user && (history.location.pathname === '/login' || history.location.pathname === '/signup')) {

--- a/client/src/context/useBookingsContext.tsx
+++ b/client/src/context/useBookingsContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+import { getBookings, updateBooking } from '../helpers/APICalls/requests';
+import { Booking } from '../interface/Booking';
+
+interface BookingsContext {
+  bookings: Booking[];
+  updateBooking: () => null;
+}
+
+interface ProviderPropTypes {
+  children: ReactNode;
+}
+
+const BookingsContext = createContext<BookingsContext>({
+  bookings: [],
+  updateBooking: () => null,
+});
+
+export const BookingsProvider = ({ children }: ProviderPropTypes) => {
+  const [bookings, setBookings] = useState([]);
+  return (
+    <BookingsContext.Provider value={{ bookings, updateBooking: () => null }}>{children}</BookingsContext.Provider>
+  );
+};
+
+export const useBookings = (): BookingsContext => useContext(BookingsContext);

--- a/client/src/context/useBookingsContext.tsx
+++ b/client/src/context/useBookingsContext.tsx
@@ -1,10 +1,10 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
-import { getBookings, updateBooking } from '../helpers/APICalls/requests';
-import { Booking } from '../interface/Booking';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import { getBookings, updateBooking, SingleBookingResponse } from '../helpers/APICalls/requests';
+import { Booking, Status } from '../interface/Booking';
 
 interface BookingsContext {
-  bookings: Booking[];
-  updateBooking: () => null;
+  bookings: Booking[] | null | undefined;
+  setBookingStatus: (id: string, status: Status) => Promise<SingleBookingResponse>;
 }
 
 interface ProviderPropTypes {
@@ -12,15 +12,49 @@ interface ProviderPropTypes {
 }
 
 const BookingsContext = createContext<BookingsContext>({
-  bookings: [],
-  updateBooking: () => null,
+  bookings: undefined,
+  setBookingStatus: async (): Promise<SingleBookingResponse> => ({}),
 });
 
 export const BookingsProvider = ({ children }: ProviderPropTypes) => {
-  const [bookings, setBookings] = useState([]);
-  return (
-    <BookingsContext.Provider value={{ bookings, updateBooking: () => null }}>{children}</BookingsContext.Provider>
-  );
+  const [bookings, setBookings] = useState<Booking[] | null | undefined>(undefined);
+  const fetchBookings = useCallback(async () => {
+    try {
+      const response = await getBookings();
+      const { success } = response;
+      if (success) {
+        success.requests.forEach((request) => {
+          const { start, end } = request;
+          request.start = new Date(start);
+          request.end = new Date(end);
+        });
+        setBookings(success.requests);
+      } else {
+        setBookings(null);
+      }
+    } catch (e) {
+      setBookings(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBookings();
+  }, [fetchBookings]);
+
+  const setBookingStatus = useCallback(async (id: string, status: Status) => {
+    const booking = await updateBooking({ status }, id);
+    setBookings((prevBookings) => {
+      if (!prevBookings) return prevBookings;
+      const bookingsCopy = [...prevBookings];
+      const updatedBooking = bookingsCopy.find((b) => b._id === id);
+      if (!updatedBooking) return prevBookings;
+      updatedBooking.status = status;
+      return bookingsCopy;
+    });
+    return booking;
+  }, []);
+
+  return <BookingsContext.Provider value={{ bookings, setBookingStatus }}>{children}</BookingsContext.Provider>;
 };
 
 export const useBookings = (): BookingsContext => useContext(BookingsContext);

--- a/client/src/helpers/APICalls/requests.ts
+++ b/client/src/helpers/APICalls/requests.ts
@@ -1,4 +1,5 @@
 import { Booking } from '../../interface/Booking';
+import { FetchOptions } from '../../interface/FetchOptions';
 
 interface BookingResponse {
   success?: {
@@ -7,8 +8,25 @@ interface BookingResponse {
   error?: string;
 }
 
-export const getBookings = async (sitter = false): Promise<BookingResponse> => {
-  const url = '/requests' + (sitter ? '?isSitter=true' : '');
-  const response = await fetch(url);
+interface SingleBookingResponse {
+  success?: {
+    requests: Booking;
+  };
+  error?: string;
+}
+
+export const getBookings = async (): Promise<BookingResponse> => {
+  const response = await fetch('/requests');
+  return response.json();
+};
+
+export const updateBooking = async (booking: Pick<Booking, 'status'>): Promise<SingleBookingResponse> => {
+  const fetchOptions: FetchOptions = {
+    credentials: 'include',
+    method: 'PATCH',
+    body: JSON.stringify(booking),
+    headers: { 'Content-Type': 'application/json' },
+  };
+  const response = await fetch('/requests', fetchOptions);
   return response.json();
 };

--- a/client/src/helpers/APICalls/requests.ts
+++ b/client/src/helpers/APICalls/requests.ts
@@ -8,7 +8,7 @@ interface BookingResponse {
   error?: string;
 }
 
-interface SingleBookingResponse {
+export interface SingleBookingResponse {
   success?: {
     requests: Booking;
   };
@@ -20,13 +20,14 @@ export const getBookings = async (): Promise<BookingResponse> => {
   return response.json();
 };
 
-export const updateBooking = async (booking: Pick<Booking, 'status'>): Promise<SingleBookingResponse> => {
+export const updateBooking = async (booking: Pick<Booking, 'status'>, id: string): Promise<SingleBookingResponse> => {
   const fetchOptions: FetchOptions = {
     credentials: 'include',
     method: 'PATCH',
     body: JSON.stringify(booking),
     headers: { 'Content-Type': 'application/json' },
   };
-  const response = await fetch('/requests', fetchOptions);
+  const url = '/requests/' + id;
+  const response = await fetch(url, fetchOptions);
   return response.json();
 };

--- a/client/src/interface/Booking.ts
+++ b/client/src/interface/Booking.ts
@@ -1,11 +1,11 @@
 import { User } from './User';
 
 export type Status = 'pending' | 'accepted' | 'declined' | 'paid';
+
 export interface Booking {
   _id: string;
   start: Date;
   end: Date;
   status: Status;
-  sitter: User;
-  owner: User;
+  otherUser: User;
 }

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -6,45 +6,25 @@ import PageContainer from '../../components/PageContainer/PageContainer';
 import NextBooking from '../../components/NextBookings/NextBooking';
 import { Booking } from '../../interface/Booking';
 import BookingList from '../../components/BookingList/BookingList';
-import { getBookings } from '../../helpers/APICalls/requests';
-import { useState, useEffect, useCallback } from 'react';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import { useBookings } from '../../context/useBookingsContext';
 
 const Bookings = () => {
   const { loggedInUser } = useAuth();
   const history = useHistory();
-  const [bookings, setBookings] = useState<Booking[]>([]);
+  const { bookings } = useBookings();
   const { updateSnackBarMessage } = useSnackBar();
-
-  const fetchBookings = useCallback(async () => {
-    try {
-      const response = await getBookings();
-      const { success } = response;
-      if (success) {
-        success.requests.forEach((request) => {
-          const { start, end } = request;
-          request.start = new Date(start);
-          request.end = new Date(end);
-        });
-        setBookings(success.requests);
-      } else {
-        updateSnackBarMessage('Error fetching bookings from server');
-      }
-    } catch (e) {
-      const { message } = e as Error;
-      updateSnackBarMessage(message);
-    }
-  }, [updateSnackBarMessage]);
-
-  useEffect(() => {
-    fetchBookings();
-  }, [fetchBookings]);
-
-  if (loggedInUser === undefined || !bookings) return <CircularProgress />;
+  if (loggedInUser === undefined || bookings === undefined) return <CircularProgress />;
   if (!loggedInUser) {
     history.push('/login');
     return <CircularProgress />;
   }
+
+  if (!bookings) {
+    updateSnackBarMessage('Error fetching bookings');
+    return <></>;
+  }
+
   const highlightedDates = bookings.filter((b) => b.status !== 'declined').map((b) => b.start.toString().slice(0, 10));
 
   const currentBookings: Booking[] = [];
@@ -60,6 +40,7 @@ const Bookings = () => {
 
   const scrollableCardStyles = {
     padding: '0px 10px 10px 10px',
+    minWidth: '280px',
     height: '300px',
     overflow: 'auto',
     '::-webkit-scrollbar': {

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -1,5 +1,3 @@
-import { useAuth } from '../../context/useAuthContext';
-import { useHistory } from 'react-router-dom';
 import { Box, Card, CircularProgress, Grid } from '@mui/material';
 import Calendar from '../../components/Calendar/Calendar';
 import PageContainer from '../../components/PageContainer/PageContainer';
@@ -10,15 +8,10 @@ import { useSnackBar } from '../../context/useSnackbarContext';
 import { useBookings } from '../../context/useBookingsContext';
 
 const Bookings = () => {
-  const { loggedInUser } = useAuth();
-  const history = useHistory();
-  const { bookings } = useBookings();
+  const { bookings, isLoadingBookings } = useBookings();
   const { updateSnackBarMessage } = useSnackBar();
-  if (loggedInUser === undefined || bookings === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    return <CircularProgress />;
-  }
+
+  if (isLoadingBookings) return <CircularProgress />;
 
   if (!bookings) {
     updateSnackBarMessage('Error fetching bookings');

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -1,6 +1,7 @@
 const Request = require("../models/Request");
 const Profile = require("../models/Profile");
 const asyncHandler = require("express-async-handler");
+const { Types } = require("mongoose");
 
 // @route GET /requests/sitter
 // @desc get requests for logged in user
@@ -10,14 +11,24 @@ exports.getRequests = asyncHandler(async (req, res) => {
     { userId: req.user.id },
     "isSitter -_id"
   );
-  const selectedUserType = isSitter ? "sitter" : "owner";
-  const requests = await Request.find({
-    [selectedUserType]: req.user.id,
-  })
-    .populate("sitter")
-    .populate("owner")
+  const currentUserType = isSitter ? "sitter" : "owner";
+  const otherUserType = isSitter ? "owner" : "sitter";
+  const queryResults = await Request.find(
+    {
+      [currentUserType]: req.user.id,
+    },
+    `-${currentUserType}`
+  )
+    .populate(otherUserType)
     .sort("start")
     .exec();
+
+  const requests = queryResults.map((r) => {
+    const request = r.toJSON();
+    request.otherUser = request[otherUserType];
+    delete request[otherUserType];
+    return request;
+  });
 
   res.status(200).json({
     success: { requests },
@@ -28,12 +39,11 @@ exports.getRequests = asyncHandler(async (req, res) => {
 // @desc Create a new request
 // @access Private
 exports.createRequest = asyncHandler(async (req, res) => {
-
   const { sitter, start, end } = req.body;
 
   const propertyIsMissing = !sitter || !start || !end;
 
-  if (propertyIsMissing || !mongoose.Types.ObjectId.isValid(sitter)) {
+  if (propertyIsMissing || !Types.ObjectId.isValid(sitter)) {
     res.status(400);
     throw new Error("Bad request");
   }
@@ -70,7 +80,7 @@ exports.updateRequestStatus = asyncHandler(async (req, res) => {
   const { requestId } = req.params;
   const request = await Request.findById(requestId);
 
-  if (!mongoose.Types.ObjectId.isValid(requestId)) {
+  if (!Types.ObjectId.isValid(requestId)) {
     res.status(400);
     throw new Error("Bad request");
   }

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -19,11 +19,6 @@ const profileSchema = new mongoose.Schema({
     required: true,
     default: false,
   },
-  isSitter: {
-    type: Boolean,
-    required: true,
-    default: false,
-  },
   name: {
     type: String,
     default: "",

--- a/server/models/Request.js
+++ b/server/models/Request.js
@@ -19,6 +19,7 @@ const requestSchema = new Schema({
     required,
     validate: {
       validator: function (start) {
+        if (!this.isNew) return true;
         const startMidnight = new Date(start);
         const currentMidnight = new Date();
 

--- a/server/models/Request.js
+++ b/server/models/Request.js
@@ -19,7 +19,6 @@ const requestSchema = new Schema({
     required,
     validate: {
       validator: function (start) {
-        if (!this.isNew) return true;
         const startMidnight = new Date(start);
         const currentMidnight = new Date();
 


### PR DESCRIPTION
### What this PR does:
- Closes #70 
- adds the ability for sitters to accept or decline bookings
- owners should be able to view the page as well but not modify the booking status
- Creates  `useBookingContext`
- The route for this feature is now a protected route

### Video:
https://www.loom.com/share/c498216a97094b0196701a6b294c4e8b


### Any information needed to test this feature (required):
- visit `/bookings` as a sitter
- create pending bookings

### Other info
- In the `Request` model I removed a duplicate `isSitter` field