### PR TITLE
Integrate profile details page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,13 +34,13 @@ function App(): JSX.Element {
                 <CssBaseline />
                 <Navbar />
                 <Switch>
-                  <Route exact path="/profile" component={Profile} />
                   <Route exact path="/bookings" component={Bookings} />
                   <Route exact path="/login" component={Login} />
                   <Route exact path="/signup" component={Signup} />
                   <Route exact path="/dashboard" component={Dashboard} />
                   <Route exact path="/listings" component={ProfileListings} />
                   <Route path="/profile/settings" component={Settings} />
+                  <Route exact path="/profile/:id" component={Profile} />
                   <Route path="*">
                     <NotFound />
                   </Route>

--- a/client/src/components/ProfileDetailsCard/Gallery.tsx
+++ b/client/src/components/ProfileDetailsCard/Gallery.tsx
@@ -1,18 +1,17 @@
 import { ImageListItem, ImageList } from '@mui/material';
+import { ImgUrlSchema } from '../../interface/Profile';
 
 interface PropTypes {
-  images: string[];
+  images: ImgUrlSchema[];
 }
 
-const Gallery = ({ images }: PropTypes) => {
-  return (
-    <ImageList cols={4} gap={10}>
-      {images.map((src, i) => (
-        <ImageListItem key={src}>
-          <img style={{ borderRadius: '5px' }} alt={`gallery item ${i + 1}`} src={src} />
-        </ImageListItem>
-      ))}
-    </ImageList>
-  );
-};
+const Gallery = ({ images }: PropTypes) => (
+  <ImageList cols={4} gap={10}>
+    {images.map(({ filePath, _id }, i) => (
+      <ImageListItem key={_id}>
+        <img style={{ borderRadius: '5px' }} alt={`gallery item ${i + 1}`} src={filePath} />
+      </ImageListItem>
+    ))}
+  </ImageList>
+);
 export default Gallery;

--- a/client/src/components/ProfileDetailsCard/ProfileDetailsCard.tsx
+++ b/client/src/components/ProfileDetailsCard/ProfileDetailsCard.tsx
@@ -7,7 +7,16 @@ interface PropTypes {
   profile: Profile;
 }
 
+const placeholderCoverPhoto = 'https://www.kimballstock.com/images/dog-stock-photos.jpg';
+const placeholderGallery = [
+  'https://i.picsum.photos/id/1062/5092/3395.jpg?hmac=o9m7qeU51uOLfXvepXcTrk2ZPiSBJEkiiOp-Qvxja-k',
+  'https://i.picsum.photos/id/1025/4951/3301.jpg?hmac=_aGh5AtoOChip_iaMo8ZvvytfEojcgqbCH7dzaz-H8Y',
+];
+
 const ProfileDetailsCard = ({ profile }: PropTypes) => {
+  profile.coverPhoto = placeholderCoverPhoto;
+  profile.uploadedImages = placeholderGallery;
+
   return (
     <Card sx={{ width: '50%' }}>
       <CardMedia image={profile.coverPhoto} title="cover photo" sx={{ minHeight: '200px' }} />
@@ -21,9 +30,10 @@ const ProfileDetailsCard = ({ profile }: PropTypes) => {
         >
           <Avatar sx={{ border: '4px solid white', width: '170px', height: '170px' }} src={profile.photo} />
           <Typography variant="h5">{profile.name}</Typography>
+          <Typography>{profile.jobTitle}</Typography>
           <Typography>
             <Room sx={{ margin: '0rem 0.3rem', color: 'primary.main' }} />
-            {profile.city}
+            {profile.address}
           </Typography>
           <Typography variant="h6" sx={{ width: '100%' }}>
             About me

--- a/client/src/components/ProfileDetailsCard/ProfileDetailsCard.tsx
+++ b/client/src/components/ProfileDetailsCard/ProfileDetailsCard.tsx
@@ -7,43 +7,26 @@ interface PropTypes {
   profile: Profile;
 }
 
-const placeholderCoverPhoto = 'https://www.kimballstock.com/images/dog-stock-photos.jpg';
-const placeholderGallery = [
-  'https://i.picsum.photos/id/1062/5092/3395.jpg?hmac=o9m7qeU51uOLfXvepXcTrk2ZPiSBJEkiiOp-Qvxja-k',
-  'https://i.picsum.photos/id/1025/4951/3301.jpg?hmac=_aGh5AtoOChip_iaMo8ZvvytfEojcgqbCH7dzaz-H8Y',
-];
-
-const ProfileDetailsCard = ({ profile }: PropTypes) => {
-  profile.coverPhoto = placeholderCoverPhoto;
-  profile.uploadedImages = placeholderGallery;
-
-  return (
-    <Card sx={{ width: '50%' }}>
-      <CardMedia image={profile.coverPhoto} title="cover photo" sx={{ minHeight: '200px' }} />
-      <CardContent sx={{ position: 'relative', bottom: '135px', marginBottom: '-135px', padding: '30px' }}>
-        <Grid
-          container
-          direction="column"
-          alignItems="center"
-          justifyContent="space-evenly"
-          sx={{ minHeight: '600px' }}
-        >
-          <Avatar sx={{ border: '4px solid white', width: '170px', height: '170px' }} src={profile.photo} />
-          <Typography variant="h5">{profile.name}</Typography>
-          <Typography>{profile.jobTitle}</Typography>
-          <Typography>
-            <Room sx={{ margin: '0rem 0.3rem', color: 'primary.main' }} />
-            {profile.address}
-          </Typography>
-          <Typography variant="h6" sx={{ width: '100%' }}>
-            About me
-          </Typography>
-          <Typography>{profile.description}</Typography>
-          <Gallery images={profile.uploadedImages} />
-        </Grid>
-      </CardContent>
-    </Card>
-  );
-};
+const ProfileDetailsCard = ({ profile }: PropTypes) => (
+  <Card sx={{ width: '50%' }}>
+    <CardMedia image={profile.coverPhoto} title="cover photo" sx={{ minHeight: '200px' }} />
+    <CardContent sx={{ position: 'relative', bottom: '135px', marginBottom: '-135px', padding: '30px' }}>
+      <Grid container direction="column" alignItems="center" justifyContent="space-evenly" sx={{ minHeight: '600px' }}>
+        <Avatar sx={{ border: '4px solid white', width: '170px', height: '170px' }} src={profile.photo} />
+        <Typography variant="h5">{profile.name}</Typography>
+        <Typography>{profile.jobTitle}</Typography>
+        <Typography>
+          <Room sx={{ margin: '0rem 0.3rem', color: 'primary.main' }} />
+          {profile.address}
+        </Typography>
+        <Typography variant="h6" sx={{ width: '100%' }}>
+          About me
+        </Typography>
+        <Typography>{profile.description}</Typography>
+        <Gallery images={profile.uploadedImages} />
+      </Grid>
+    </CardContent>
+  </Card>
+);
 
 export default ProfileDetailsCard;

--- a/client/src/components/RequestForm/RequestForm.tsx
+++ b/client/src/components/RequestForm/RequestForm.tsx
@@ -48,7 +48,6 @@ const RequestForm = ({ profile }: PropTypes) => {
     }
   };
 
-  profile.averageRating = placeholderAverageRating;
   return (
     <Card sx={{ width: '25%', minWidth: '250px' }}>
       <form onSubmit={handleSubmit}>
@@ -61,7 +60,7 @@ const RequestForm = ({ profile }: PropTypes) => {
         >
           <Typography variant="h6">${profile.hourlyRate}/hr</Typography>
           <Grid item>
-            <Rating readOnly value={profile.averageRating} />
+            <Rating readOnly value={placeholderAverageRating} />
           </Grid>
           <DateTimePicker
             disabled={!loggedInUser}

--- a/client/src/components/RequestForm/RequestForm.tsx
+++ b/client/src/components/RequestForm/RequestForm.tsx
@@ -1,24 +1,54 @@
 import { DateTimePicker } from '@mui/lab';
 import { Button, Card, Grid, Rating, TextField, Typography } from '@mui/material';
 import { FormEvent, useState } from 'react';
+import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import { createBooking } from '../../helpers/APICalls/requests';
 import { Profile } from '../../interface/Profile';
 
 interface PropTypes {
   profile: Profile;
 }
+
 const MILLISECONDS_PER_HOUR = 3.6e6;
+
+const placeholderAverageRating = 3;
+
 const RequestForm = ({ profile }: PropTypes) => {
   const hourFromNowTimestamp = Date.now() + MILLISECONDS_PER_HOUR;
   const [dropoff, setDropoff] = useState<Date | null>(new Date());
   const [pickup, setPickup] = useState<Date | null>(new Date(hourFromNowTimestamp));
+  const { loggedInUser } = useAuth();
   const { updateSnackBarMessage } = useSnackBar();
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    updateSnackBarMessage('Request sent');
+    if (!dropoff || !pickup) {
+      updateSnackBarMessage('Dropoff and pickup must be valid');
+      return;
+    }
+    const reqBody = {
+      sitter: profile.userId,
+      start: dropoff,
+      end: pickup,
+    };
+    try {
+      setIsButtonDisabled(true);
+      const { success } = await createBooking(reqBody);
+      if (success) {
+        updateSnackBarMessage('Request sent');
+      } else {
+        updateSnackBarMessage('Error sending request');
+      }
+    } catch (e) {
+      updateSnackBarMessage('Error sending request');
+    } finally {
+      setIsButtonDisabled(false);
+    }
   };
 
+  profile.averageRating = placeholderAverageRating;
   return (
     <Card sx={{ width: '25%', minWidth: '250px' }}>
       <form onSubmit={handleSubmit}>
@@ -34,18 +64,20 @@ const RequestForm = ({ profile }: PropTypes) => {
             <Rating readOnly value={profile.averageRating} />
           </Grid>
           <DateTimePicker
+            disabled={!loggedInUser}
             label="Drop off"
             value={dropoff}
             onChange={setDropoff}
             renderInput={(params) => <TextField {...params} />}
           />
           <DateTimePicker
+            disabled={!loggedInUser}
             label="Pick up"
             value={pickup}
             onChange={setPickup}
             renderInput={(params) => <TextField {...params} />}
           />
-          <Button type="submit" variant="contained">
+          <Button type="submit" variant="contained" disabled={isButtonDisabled || !loggedInUser}>
             send request
           </Button>
         </Grid>

--- a/client/src/helpers/APICalls/editProfile.ts
+++ b/client/src/helpers/APICalls/editProfile.ts
@@ -16,7 +16,7 @@ const editProfile = async (data: {
     body: JSON.stringify(data),
     credentials: 'include',
   };
-  return await fetch(`/profile/edit`, fetchOptions)
+  return await fetch(`/profile/`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },

--- a/client/src/helpers/APICalls/profile.ts
+++ b/client/src/helpers/APICalls/profile.ts
@@ -8,6 +8,6 @@ interface ProfileResponse {
 }
 
 export const getProfile = async (id: string): Promise<ProfileResponse> => {
-  const response = await fetch('/profile/load/' + id);
+  const response = await fetch('/profile/' + id);
   return response.json();
 };

--- a/client/src/helpers/APICalls/profile.ts
+++ b/client/src/helpers/APICalls/profile.ts
@@ -1,0 +1,13 @@
+import { Profile } from '../../interface/Profile';
+
+interface ProfileResponse {
+  success?: {
+    profile: Profile;
+  };
+  error?: string;
+}
+
+export const getProfile = async (id: string): Promise<ProfileResponse> => {
+  const response = await fetch('/profile/load/' + id);
+  return response.json();
+};

--- a/client/src/helpers/APICalls/requests.ts
+++ b/client/src/helpers/APICalls/requests.ts
@@ -1,4 +1,5 @@
 import { Booking } from '../../interface/Booking';
+import { FetchOptions } from '../../interface/FetchOptions';
 
 interface BookingResponse {
   success?: {
@@ -7,8 +8,32 @@ interface BookingResponse {
   error?: string;
 }
 
+export interface SingleBookingResponse {
+  success?: {
+    requests: Booking;
+  };
+  error?: string;
+}
+
+export interface PostBody {
+  sitter: string;
+  start: Date;
+  end: Date;
+}
+
 export const getBookings = async (sitter = false): Promise<BookingResponse> => {
   const url = '/requests' + (sitter ? '?isSitter=true' : '');
   const response = await fetch(url);
+  return response.json();
+};
+
+export const createBooking = async (body: PostBody): Promise<SingleBookingResponse> => {
+  const fetchOptions: FetchOptions = {
+    credentials: 'include',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+  const response = await fetch('/requests', fetchOptions);
   return response.json();
 };

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,11 +1,13 @@
 export interface Profile {
+  _id: string;
   coverPhoto: string;
   photo: string;
   uploadedImages: string[];
   name: string;
   description: string;
   hourlyRate: number;
-  availability: boolean[];
-  city: string;
+  address: string;
   averageRating: number;
+  jobTitle: string;
+  userId: string;
 }

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,13 +1,17 @@
+export interface ImgUrlSchema {
+  _id: string;
+  filePath: string;
+}
+
 export interface Profile {
   _id: string;
   coverPhoto: string;
   photo: string;
-  uploadedImages: string[];
+  uploadedImages: ImgUrlSchema[];
   name: string;
   description: string;
   hourlyRate: number;
   address: string;
-  averageRating: number;
   jobTitle: string;
   userId: string;
 }

--- a/client/src/pages/Profile/ProfilePage.tsx
+++ b/client/src/pages/Profile/ProfilePage.tsx
@@ -1,36 +1,45 @@
 import { CircularProgress, Grid } from '@mui/material';
-import { useHistory } from 'react-router-dom';
+import { useCallback, useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import ProfileDetailsCard from '../../components/ProfileDetailsCard/ProfileDetailsCard';
 import RequestForm from '../../components/RequestForm/RequestForm';
-import { useAuth } from '../../context/useAuthContext';
+import { getProfile } from '../../helpers/APICalls/profile';
 import { Profile } from '../../interface/Profile';
+import NotFound from '../NotFound/NotFound';
 
-const profile: Profile = {
-  city: 'Toronto',
-  availability: [true, false, false, false, false, false, true],
-  coverPhoto: 'https://www.kimballstock.com/images/dog-stock-photos.jpg',
-  description:
-    'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
-  hourlyRate: 5,
-  name: 'Norma Byers',
-  photo: 'https://thoughtcatalog.com/wp-content/uploads/2016/04/24597829769_1c5fd5517a_k.jpg',
-  uploadedImages: [
-    'https://i.picsum.photos/id/1062/5092/3395.jpg?hmac=o9m7qeU51uOLfXvepXcTrk2ZPiSBJEkiiOp-Qvxja-k',
-    'https://i.picsum.photos/id/1025/4951/3301.jpg?hmac=_aGh5AtoOChip_iaMo8ZvvytfEojcgqbCH7dzaz-H8Y',
-  ],
-  averageRating: 3,
-};
+interface RouteParams {
+  id: string;
+}
 
 const ProfilePage = () => {
-  const { loggedInUser } = useAuth();
-  const history = useHistory();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const { id } = useParams<RouteParams>();
 
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    return <CircularProgress />;
-  }
+  const fetchProfile = useCallback(async (id: string) => {
+    try {
+      setIsLoading(true);
+      const { success } = await getProfile(id);
+      if (success) {
+        setProfile(success.profile);
+      } else {
+        setProfile(null);
+      }
+    } catch (e) {
+      setProfile(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile(id);
+  }, [fetchProfile, id]);
+
+  if (isLoading) return <CircularProgress />;
+  if (!profile) return <NotFound />;
+
   return (
     <PageContainer>
       <Grid container justifyContent="space-evenly" alignItems="flex-start">

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -1,10 +1,27 @@
 const Profile = require("../models/Profile");
 const asyncHandler = require("express-async-handler");
-const path = require("path");
+const { Types } = require("mongoose");
 const fs = require("fs");
 const util = require("util");
 const unlinkFile = util.promisify(fs.unlink);
 const { uploadImages } = require("../s3");
+
+// @route GET /profile/load/:id
+// @desc Get user profile data
+// @access Public
+exports.loadProfileById = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  if (!Types.ObjectId.isValid(id)) {
+    res.status(400);
+    throw new Error("Bad request");
+  }
+
+  const profile = await Profile.findById(id);
+  res.status(200).json({
+    success: { profile },
+  });
+});
 
 // @route PUT /profile/edit
 // @desc edit user profile

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -1,6 +1,7 @@
 const Request = require("../models/Request");
 const Profile = require("../models/Profile");
 const asyncHandler = require("express-async-handler");
+const { Types } = require("mongoose");
 
 // @route GET /requests/sitter
 // @desc get requests for logged in user
@@ -32,7 +33,7 @@ exports.createRequest = asyncHandler(async (req, res) => {
 
   const propertyIsMissing = !sitter || !start || !end;
 
-  if (propertyIsMissing || !mongoose.Types.ObjectId.isValid(sitter)) {
+  if (propertyIsMissing || !Types.ObjectId.isValid(sitter)) {
     res.status(400);
     throw new Error("Bad request");
   }
@@ -69,7 +70,7 @@ exports.updateRequestStatus = asyncHandler(async (req, res) => {
   const { requestId } = req.params;
   const request = await Request.findById(requestId);
 
-  if (!mongoose.Types.ObjectId.isValid(requestId)) {
+  if (!Types.ObjectId.isValid(requestId)) {
     res.status(400);
     throw new Error("Bad request");
   }

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -52,6 +52,25 @@ const profileSchema = new mongoose.Schema({
     type: String,
     default: "",
   },
+  jobTitle: {
+    type: String,
+    max: 20,
+    trim: "",
+    default: "",
+  },
+  coverPhoto: {
+    type: String,
+    default: "",
+  },
+  hourlyRate: {
+    type: Number,
+    validate: [
+      function (val) {
+        return val > 0;
+      },
+      "Hourly rate must be a positive number",
+    ],
+  },
   uploadedImages: [imgUrlSchema],
 });
 

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -19,11 +19,6 @@ const profileSchema = new mongoose.Schema({
     required: true,
     default: false,
   },
-  isSitter: {
-    type: Boolean,
-    required: true,
-    default: false,
-  },
   name: {
     type: String,
     default: "",

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -6,6 +6,7 @@ const protect = require("../middleware/auth");
 const {
   editProfile,
   loadProfile,
+  loadProfileById,
   retriveImgUrls,
 } = require("../controllers/profile");
 
@@ -36,6 +37,7 @@ router
 
 router.route("/edit").put(protect, editProfile);
 
+router.route("/load/:id").get(loadProfileById);
 router.route("/load").get(protect, loadProfile);
 
 module.exports = router;

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -35,9 +35,9 @@ router
   .route("/upload")
   .post(protect, upload.array("images", 5), retriveImgUrls);
 
-router.route("/edit").put(protect, editProfile);
+router.route("/").put(protect, editProfile);
 
-router.route("/load/:id").get(loadProfileById);
-router.route("/load").get(protect, loadProfile);
+router.route("/:id").get(loadProfileById);
+router.route("/").get(protect, loadProfile);
 
 module.exports = router;


### PR DESCRIPTION
## What this PR does:
- Closes #35
- Makes the profile page dynamic based on id route parameter
### Client-side changes
- adds the `jobTitle` field to the profile
- add placeholders for rating,  galleries, and cover photo until features are added
- rename `profile.city` to `profile.address`
- update profile interface to reflect updated model
- create api calls to `POST  /requests` and `GET /profile/:id`
- remove placeholder profile to use route parameter in api call instead
- add submit functionality for request form 
  - after user presses submit, the button will be disabled until the request is fulfilled or failed
  - meanwhile the API call is made
### Server-side changes
  - Create `GET /load/:id` controller and route
  - Fix problem where mongoose is not imported
  - add fields to Profile model

## Video:
https://www.loom.com/share/5b080c11b382403abe6e427905d3dbe5

## Any information needed to test this feature (required):
- Create owner and sitter
- Send request as owner to sitter at `/profile/:id` (`:id` being the profile id of the sitter)


